### PR TITLE
Add filter_from_bam command 

### DIFF
--- a/fast5_research/__init__.py
+++ b/fast5_research/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.2.20'
+__version__ = '1.2.21'
 
 from fast5_research.fast5 import Fast5, iterate_fast5
 from fast5_research.fast5_bulk import BulkFast5

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ futures
 h5py<2.9.0     # causes some tests to fail
 numpy>=1.14.0  # 1.14 made some relatively big changes
 progressbar2
+pysam
+

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
             'extract_reads = {}.extract:extract_reads'.format(__pkg_name__),
             'read_summary = {}.extract:extract_read_summary'.format(__pkg_name__),
             'filter_reads = {}.extract:filter_multi_reads'.format(__pkg_name__),
+            'filter_from_bam = {}.extract:filter_file_from_bam'.format(__pkg_name__),
         ]
     },
     license='Mozilla Public License 2.0',


### PR DESCRIPTION
Extracts ids from reads overlaping with a given region, gets fast5 filenames for each id and writes them to a tsv file.

Adds pysam as a dependency.

Example:
```bash
$ filter_from_bam -r chr21 --seperator ',' HG002_GM24385_1_2_3_Guppy_3.6.0_prom.bam /mmfs1/data/active/projects/202004_pangenome_rebasecall/SUMMARY/20200428_*_PR.3.6.0.hac_prom.csv.gz > HG002_GM24385_1_2_3_Guppy_3.6.0_prom.bam_chr21_readsids.tsv
$ filter_reads fast5/ HG002_GM24385_1_2_3_Guppy_3.6.0_prom.bam_chr21_fast5s/ HG002_GM24385_1_2_3_Guppy_3.6.0_prom.bam_chr21_readsids.tsv --workers 48 --multi --recursive
```