### PR TITLE
Change progressbar to be compatible with ont_fast5_api

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@
 futures
 h5py<2.9.0     # causes some tests to fail
 numpy>=1.14.0  # 1.14 made some relatively big changes
-progressbar2
+progressbar33>=2.3.1
 pysam
 


### PR DESCRIPTION
Currently if you install both into a venv, which is commonly done for ad hoc manipulation of ONT fast5s, ont_fast5_api can give this error `RuntimeError: Wrong progressbar package detected, likely "progressbar2". Please uninstall that package and install "progressbar33" instead.`. This change avoids the error with minimal impact to fast5_research.