### PR TITLE
Add None as acceptable time input

### DIFF
--- a/fast5_research/fast5_bulk.py
+++ b/fast5_research/fast5_bulk.py
@@ -179,6 +179,9 @@ class BulkFast5(h5py.File):
 
     def _seconds_to_index(self, channel, time):
         """Translate a point in time to an index."""
+        if time is None:
+            return None
+
         return int(time * float(self.sample_rate))
 
 

--- a/fast5_research/test/test_fast5_bulk.py
+++ b/fast5_research/test/test_fast5_bulk.py
@@ -87,6 +87,15 @@ class BulkFast5Test(unittest.TestCase):
         raw = self.fh.get_raw(self.fh.channels[0])
         self.assertEqual(len(raw), 1212525)
 
+
+    def test_parse_times_with_None(self):
+        """Test that times=(None, None) defaults to the whole raw data"""
+
+        raw = self.fh.get_raw(self.fh.channels[0])
+        raw_with_Nones = self.fh.get_raw(self.fh.channels[0], times=(None, None))
+        self.assertEqual(len(raw), len(raw_with_Nones))
+
+
     def test_parse_event_data_len(self):
         """Test parsing the whole event dataset"""
 


### PR DESCRIPTION
Allow accessing times using, e.g., `fh.get_raw(12, times=(100, None))` to remove first 100 seconds of the raw data. 